### PR TITLE
Update bootStrap version

### DIFF
--- a/theSite/packages.config
+++ b/theSite/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
-  <package id="bootstrap" version="3.0.0" targetFramework="net45" />
+  <package id="bootstrap" version="3.4.1" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
   <package id="jQuery" version="1.10.2" targetFramework="net45" />
   <package id="jQuery.Validation" version="1.11.1" targetFramework="net45" />


### PR DESCRIPTION
Update bootStrap version.
 bootstrap vulnerability found in theSite/packages.config on Feb 23
Remediation
Upgrade bootstrap to version 3.4.1 or later. For example:

<package id="bootstrap" version="3.4.1" />
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2019-8331 More information
moderate severity
Vulnerable versions: >= 3.0.0, < 3.4.1
Patched version: 3.4.1
In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/